### PR TITLE
fix bitarray > 0.8.1 incompatible w/ basil-daq (BitLogic submodule)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ author = ''
 author_email = ''
 
 # Requirements
-install_requires = ['basil-daq==3.0.1', 'bitarray>=0.8.1', 'matplotlib',
+install_requires = ['basil-daq==3.0.1', 'bitarray==0.8.1', 'matplotlib',
                     'numpy', 'online_monitor>=0.4.0<0.5',
                     'pixel_clusterizer==3.1.3', 'tables', 'pyyaml', 'pyzmq',
                     'scipy', 'numba', 'tqdm']


### PR DESCRIPTION
Basil 3.0.1 is incompatible with some version of bitarray. On my
machine bitarray 2.1.0 was installed alongside basil-daq 3.0.1, which
breaks the BitLogic.py submodule, because the `bitarray` class does
not have a `length` method any longer.

Unfortunately I don't know which version introduced this breaking change (feel free to investigate.. :) ).